### PR TITLE
Fixed Bug: Server throws error when supabase table is empty

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -24,7 +24,7 @@ export default {
           .from("documents")
           .select("document")
           .eq("name", room.id)
-          .single();
+          .maybeSingle();
 
         if (error) {
           console.error("ERROR", error);

--- a/src/tiptap.tsx
+++ b/src/tiptap.tsx
@@ -35,7 +35,7 @@ const Tiptap = () => {
     ],
   });
 
-  return <EditorContent editor={editor} />;
+  return <EditorContent style={{ border: "solid" }} editor={editor} />;
 };
 
 export default Tiptap;


### PR DESCRIPTION
This PR fixes a bug that would throw an error when the supabase table was empty.

Additionally, a black border was added to the editor so that it is visible when the supabase table is empty.